### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "python -m http.server --cgi 8000"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Vortex-Web
 
 Webpage i made cuz yeah
+
+[![Run on Repl.it](https://repl.it/badge/github/IzanLarumbe/Vortex-Web)](https://repl.it/github/IzanLarumbe/Vortex-Web)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@V3rmillionNet/Vortex-Web-1).